### PR TITLE
Fix deploy docs permissions

### DIFF
--- a/.github/workflows/deploy_docs_master.yaml
+++ b/.github/workflows/deploy_docs_master.yaml
@@ -48,5 +48,5 @@ jobs:
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
-          personal_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./${{ inputs.docs_dir }}/build/html


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
The deploy docs action does not seem to be able to get the permissions it needs to do the final deployment of documentation (see the error in the most recent action in CMakePPLang [here](https://github.com/CMakePP/CMakePPLang/actions/runs/3751488080/jobs/6372527490)). The deploy action uses the 'personal_token' input with the 'secrets.GITHUB_TOKEN' variable, which may be causing the issue.
