### PR TITLE
Add checks and outputs for patch version in tag_and_release

### DIFF
--- a/.github/workflows/tag_and_release_master.yaml
+++ b/.github/workflows/tag_and_release_master.yaml
@@ -27,6 +27,10 @@ on:
       bumped_minor:
         description: "Did we bump the minor?"
         value: ${{ jobs.update_version.outputs.bumped_minor }}
+      bumped_patch:
+        description: "Did we bump the patch?"
+        value: ${{ jobs.update_version.outputs.bumped_patch }}
+
 
 jobs:
   update_version:
@@ -34,6 +38,7 @@ jobs:
     outputs:
       bumped_major: ${{ steps.compute_output.outputs.bumped_major }}
       bumped_minor: ${{ steps.compute_output.outputs.bumped_minor }}
+      bumped_patch: ${{ steps.compute_output.outputs.bumped_patch }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -51,16 +56,30 @@ jobs:
           next_version=${{ steps.bumpr.outputs.next_version }}
           current_major="$(echo ${current_version} | cut -d'.' -f1)"
           next_major="$(echo ${next_version} | cut -d'.' -f1)"
-          if [[ "${current_major}" == "${next_major}" ]]; then
+          if [[ "${current_major}" -ge "${next_major}" ]]; then
             echo "bumped_major=false" >> $GITHUB_OUTPUT
+            echo "DEBUG: Not bumping major"
           else
-            echo "bumped_major=true" >>$GITHUB_OUTPUT
+            echo "bumped_major=true" >> $GITHUB_OUTPUT
+            echo "DEBUG: Bumping major"
           fi
           current_minor="$(echo ${current_version} | cut -d'.' -f2)"
           next_minor="$(echo ${next_version} | cut -d'.' -f2)"
-          if [[ "${current_minor}" == "${next_minor}" ]]; then
+          if [[ "${current_minor}" -ge "${next_minor}" ]]; then
             echo "bumped_minor=false" >> $GITHUB_OUTPUT
+            echo "DEBUG: Not bumping minor"
           else
             echo "bumped_minor=true" >> $GITHUB_OUTPUT
+            echo "DEBUG: Bumping minor"
+          fi
+
+          current_patch="$(echo ${current_version} | cut -d'.' -f3)"
+          next_patch="$(echo ${next_version} | cut -d'.' -f3)"
+          if [[ "${current_patch}" -ge "${next_patch}" ]]; then
+            echo "bumped_patch=false" >> $GITHUB_OUTPUT
+            echo "DEBUG: Not bumping patch"
+          else
+            echo "bumped_patch=true" >> $GITHUB_OUTPUT
+            echo "DEBUG: Bumping patch"
           fi
 


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
Fixes #14 and fixes #13 

**Description**
This PR adds checks and another output in the update_version job for the patch number in the version. This should allow a proper fix for CMakePP/Cminx#138. It also adds debug logging in case the issue isn't fixed, and it switches the equality operators in the conditionals to greater-than-or-equal operators so that version jumps that reset lower numbers to zero don't set the output for that reset number (1.1.6-1.2.0 will set bumped_minor only, not patch). It probably doesn't matter but for such a simple change may as well
