### PR TITLE
Update deploy docs to use secret token passed in

### DIFF
--- a/.github/workflows/deploy_docs_master.yaml
+++ b/.github/workflows/deploy_docs_master.yaml
@@ -48,5 +48,5 @@ jobs:
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.token }}
           publish_dir: ./${{ inputs.docs_dir }}/build/html


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
Potentially [PR 68](https://github.com/CMakePP/CMakePPLang/issues/68) in CMakePPLang.

**Description**
I believe that `${{ secrets.token }}` should be used to reference the token being passed into the `deploy_docs` reusable workflow, not `${{ secrets.GITHUB_TOKEN }}`.
