### PR TITLE
Generalize docs directory used in Build Docs step

### DIFF
--- a/.github/workflows/deploy_docs_master.yaml
+++ b/.github/workflows/deploy_docs_master.yaml
@@ -32,19 +32,29 @@ on:
 jobs:
   Build-Documentation:
     runs-on: ubuntu-latest
+    
     steps:
       - uses: actions/checkout@v2
+      
       - uses: actions/setup-python@v1
         with:
           python-version: ${{ inputs.python_version }}
+          
       - name: Build Docs
+        env:
+          docs_dir: ${{ inputs.docs_dir }}
         run: |
+          # Create and activate a virtual environment to install Python packages
           python3 -m venv virt_env
           source virt_env/bin/activate
-          cd docs
+          
+          # Install documentation required packages
+          cd ${docs_dir}
           pip3 install -r requirements.txt
+          
+          # Build the documentation
           make html
-          deactivate
+          
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
While a `docs_dir` input is defined, it is not used during the "Build Docs" step, instead always doing `cd docs`. This generalizes it to use the `docs_dir` input directory.

Edit: It also adds some whitespace and comments.
