### PR TITLE
Fix deploy_docs action

### DIFF
--- a/.github/workflows/deploy_docs.yaml
+++ b/.github/workflows/deploy_docs.yaml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   Build-Documentation:
-    if: github.event.pull_request.merged == true
+    if: github.event_name != 'pull_request' || github.event.pull_request.merged == true
     uses: CMakePP/.github/.github/workflows/deploy_docs_master.yaml@main
     with:
       docs_dir: 'docs'

--- a/.github/workflows/deploy_docs.yaml
+++ b/.github/workflows/deploy_docs.yaml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   Build-Documentation:
-    if: github.event_name != 'pull_request' || github.event.pull_request.merged == true
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     uses: CMakePP/.github/.github/workflows/deploy_docs_master.yaml@main
     with:
       docs_dir: 'docs'


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
Attempts to fix CMakePPLang [issue 93](https://github.com/CMakePP/CMakePPLang/issues/93).

**Description**
The `deploy_docs` workflow does not seem to be triggering on pull requests, and it is skipped when it is manually triggered. This PR will attempt to fix those issues so our documentation website is generated properly.

**TODOs**
- [x] I suspect that the workflow is skipped when manually triggered because of the `if: github.event.pull_request.merged == true` line, since there isn't a pull request being merged. This should be fixed by saying "if the event is the workflow being triggered manually OR a pull request was merged, run the workflow".
- [ ] Figure out why it is not triggering on PRs. This will probably actually be solved in a later PR if this one is merged and the fix doesn't stick.
