### PR TITLE
Fix deploy_docs action to trigger on PR closing

### DIFF
--- a/.github/workflows/deploy_docs.yaml
+++ b/.github/workflows/deploy_docs.yaml
@@ -17,7 +17,7 @@ name: Build and Deploy Documentation
 on:
   pull_request:
     types:
-      - main
+      - closed
       
   # Allows manual triggering with the "Run workflow" button
   workflow_dispatch:


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
Fixes #27.

**Description**
The PR type that the [deploy_docs.yaml](https://github.com/CMakePP/.github/blob/main/.github/workflows/deploy_docs.yaml) action should trigger on was not correct. This PR fixes it to trigger when a PR is closed.
